### PR TITLE
Put frame extraction back into the script

### DIFF
--- a/src/duke/downloadDukeMTMC.m
+++ b/src/duke/downloadDukeMTMC.m
@@ -9,6 +9,7 @@ GET_ALL               = false; % Set this to true if you want to download everyt
 GET_GROUND_TRUTH      = true;
 GET_CALIBRATION       = true;
 GET_VIDEOS            = true;
+GET_FRAMES            = false;
 GET_DPM               = false;
 GET_OPENPOSE          = true;
 GET_FGMASKS           = false;
@@ -84,6 +85,19 @@ if GET_ALL || GET_VIDEOS
     fprintf('Data download complete.\n');
 end
 
+%% Extract frames
+if GET_ALL || (GET_VIDEOS && GET_FRAMES)
+    fprintf('Extracting frames...\n');
+    currDir = pwd;
+    for cam = 1:dataset.numCameras
+        cd([dataset.savePath 'videos/camera' num2str(cam)]); 
+        filelist = '"concat:00000.MTS';
+        for k = 1:dataset.videoParts(cam), filelist = [filelist, '|0000', num2str(k), '.MTS']; end; 
+        framesDir = [dataset.savePath 'frames/camera' num2str(cam) '/%06d.jpg'];
+        command = [ffmpegPath ' -i ' filelist '" -qscale:v 1 -f image2 ' framesDir];
+        system(command);
+    end
+end
 
 %% Download DPM detections
 if GET_ALL || GET_DPM


### PR DESCRIPTION
In the previous version of the download script, ffmpeg was used to extract all the frames from the video. In the new version, this disappeared, so this fork puts it back in with a flag that is false by default (and also dependent on the videos being downloaded).